### PR TITLE
Changes pickle to cPickle

### DIFF
--- a/pathofexile/utilities.py
+++ b/pathofexile/utilities.py
@@ -1,6 +1,9 @@
 import grequests
 import os
-import pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 import time
 
 import pathofexile.api


### PR DESCRIPTION
Using cPickle instead of pickle on my computer:
1. reduced the call of pickle.dump from about 4s to 1s when caching a ladder.
2. reduced the call of pickle.load from about 3s to 1s when retrieving a ladder from the cache. 
