### PR TITLE
Replace / with _ when caching

### DIFF
--- a/pathofexile/ladder/__init__.py
+++ b/pathofexile/ladder/__init__.py
@@ -46,7 +46,10 @@ def cache(original_function):
     def load_if_present(ladder_id, force_redownload=False):
         one_hour = 3600  # seconds
         cache_dir = '.ladder_cache'
-        pickle_file = '{0}/{1}'.format(cache_dir, ladder_id.replace(' ', ''))
+        pickle_file = '{0}/{1}'.format(
+            cache_dir,
+            ladder_id.replace(' ', '').replace('/', '_')
+        )
 
         # determine if loading from cache is an option
         if os.path.isfile(pickle_file) and not force_redownload:


### PR DESCRIPTION
This prevents pickle from getting confused about directories for leagues like 'OneWeekHCRampage/Beyond'. Specifically it fixes `IOError: [Errno 2] No such file or directory: '.ladder_cache/OneWeekHCRampage/Beyond'`.